### PR TITLE
docs: Update README.md CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jobs:
       # add Socket Firewall to the runner environment
       - uses: socketdev/action@v1
         with:
-          mode: firewall-free
+          mode: firewall
       
       # setup your project (e.g. checkout, setup-node, etc...)
       - uses: actions/checkout@v5


### PR DESCRIPTION
This PR updates a minor issue I encountered when following the CI example. The GitHub action mode should be ` mode: firewall` or ` mode: cli`. 